### PR TITLE
Fix query condition to be from the correct level in hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 vendor/**
-.idea

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ projects by using Illuminate/Database.
 
 A simple to use query builder for the [jQuery QueryBuilder plugin](http://mistic100.github.io/jQuery-QueryBuilder/).
 
+```php
     use timgws\QueryBuilderParser;
 
     $table = DB::table('table_of_data_to_interegate');
@@ -23,6 +24,7 @@ A simple to use query builder for the [jQuery QueryBuilder plugin](http://mistic
 
     $rows = $query->get();
     return Response::JSON($rows);
+```
 
 Mixed with Datatables, this makes for some true awesome.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Mixed with Datatables, this makes for some true awesome.
     }
 ```
 
+## Known issues
+Some complex queries with QueryBuilder 2.1.0 are failing.
 
 ## Reporting Issues
 

--- a/src/QueryBuilderParser/QueryBuilderParser.php
+++ b/src/QueryBuilderParser/QueryBuilderParser.php
@@ -196,7 +196,7 @@ class QueryBuilderParser {
      * @param $rule
      * @return null|string
      */
-    private function operatorValueWhenNotAcceptingOne($rule)
+    private function operatorValueWhenNotAcceptingOne(stdClass $rule)
     {
         if ($this->operators[$rule->operator]['accept_values'] === false) {
             if ($rule->operator == 'is_empty' || $rule->operator == 'is_not_empty')

--- a/tests/QueryBuilderParserTest.php
+++ b/tests/QueryBuilderParserTest.php
@@ -291,15 +291,27 @@ class QueryBuilderParserTest extends PHPUnit_Framework_TestCase
      * @expectedException \timgws\QBParseException
      * @expectedExceptionMessage Field (price) should be an array, but it isn't.
      */
-    public function testBetweenMustBeArray()
+    public function testBetweenMustBeArray($validJSON = true)
     {
         $json = '{"condition":"AND","rules":['
             . '{"id":"price","field":"price","type":"double","input":"text",'
             . '"operator":"between","value":"1"}]}';
 
+        if (!$validJSON)
+            $json .= '[';
+
         $builder = $this->createQueryBuilder();
         $qb = new QueryBuilderParser();
         $test = $qb->parse($json, $builder);
+    }
+
+    /**
+     * @expectedException \timgws\QBParseException
+     * @expectedExceptionMessage JSON parsing threw an error
+     */
+    public function testThrowExceptionInvalidJSON()
+    {
+        $this->testBetweenMustBeArray(false /*invalid json*/);
     }
 
     /**


### PR DESCRIPTION
As per https://github.com/timgws/QueryBuilderParser/issues/5 the query condition is currently being taken from the wrong level in the parse tree. This fixes that - but is definitely a breaking change for any dependent code, since it changes many and/or conditions.