### PR TITLE
Less strict validation

### DIFF
--- a/src/QueryBuilderParser/QBPFunctions.php
+++ b/src/QueryBuilderParser/QBPFunctions.php
@@ -183,7 +183,7 @@ trait QBPFunctions
             throw new QBParseException('JSON parsing threw an error: '.json_last_error_msg());
         }
 
-        if (!is_object($query)) {
+        if ($query && !is_object($query)) {
             throw new QBParseException('The query is not valid JSON');
         }
 


### PR DESCRIPTION
When $json is `[]` (empty rules), queryBuilder should return clear Builder object instead of throwing error