### PR TITLE
Remove "input" from required rule fields, because it's not guaranteed to exist

### DIFF
--- a/src/QueryBuilderParser/QueryBuilderParser.php
+++ b/src/QueryBuilderParser/QueryBuilderParser.php
@@ -136,7 +136,7 @@ class QueryBuilderParser
      */
     protected function checkRuleCorrect(stdClass $rule)
     {
-        if (!isset($rule->operator, $rule->id, $rule->field, $rule->input, $rule->type)) {
+        if (!isset($rule->operator, $rule->id, $rule->field, $rule->type)) {
             return false;
         }
 

--- a/tests/CommonQueryBuilderTests.php
+++ b/tests/CommonQueryBuilderTests.php
@@ -10,7 +10,7 @@ use timgws\QueryBuilderParser;
 
 class CommonQueryBuilderTests extends \PHPUnit_Framework_TestCase
 {
-    protected $simpleQuery = '{"condition":"AND","rules":[{"id":"price","field":"price","type":"double","input":"text","operator":"less","value":"10.25"}]}';
+    protected $simpleQuery = '{"condition":"AND","rules":[{"id":"price","field":"price","type":"double","operator":"less","value":"10.25"}]}';
     protected $json1 = '{
        "condition":"AND",
        "rules":[
@@ -18,7 +18,6 @@ class CommonQueryBuilderTests extends \PHPUnit_Framework_TestCase
              "id":"price",
              "field":"price",
              "type":"double",
-             "input":"text",
              "operator":"less",
              "value":"10.25"
           },
@@ -29,7 +28,6 @@ class CommonQueryBuilderTests extends \PHPUnit_Framework_TestCase
                    "id":"name",
                    "field":"name",
                    "type":"string",
-                   "input":"text",
                    "operator":"begins_with",
                    "value":"Thommas"
                 },
@@ -37,7 +35,6 @@ class CommonQueryBuilderTests extends \PHPUnit_Framework_TestCase
                    "id":"name",
                    "field":"name",
                    "type":"string",
-                   "input":"text",
                    "operator":"equal",
                    "value":"John Doe"
                 }
@@ -72,7 +69,6 @@ class CommonQueryBuilderTests extends \PHPUnit_Framework_TestCase
                  "id":"price",
                  "field":"price",
                  "type":"double",
-                 "input":"text",
                  "operator":"less",
                  "value":"10.25"
               },
@@ -82,7 +78,6 @@ class CommonQueryBuilderTests extends \PHPUnit_Framework_TestCase
                    "id":"category",
                    "field":"category",
                    "type":"integer",
-                   "input":"select",
                    "operator":"'.$operator.'",
                    "value":[
                       "1", "2"


### PR DESCRIPTION
`input` field will be omitted from rules json when a function is used to generate it:
```js
{
  id: 'test',
  type: 'string',
  input: function(rule, input_name) {
    return `<input class="form-control" type="text" name=${input_name} />`
  }
}
```

QueryBuilderParser will then do an overzealous check, and drop the rule all together from the query.

It's worth considering that most rule fields are not guaranteed to exist: https://github.com/mistic100/jQuery-QueryBuilder/blob/2a237884b8a665ed9757a4ce08166b8d9e2b24d6/src/public.js#L257-L264

Perhaps `id` and `type` do not need to be verified for existence either?